### PR TITLE
feat(workflow): @hermes mention listener (reusable)

### DIFF
--- a/.github/workflows/hermes-pr-tag-listener.call.yml.example
+++ b/.github/workflows/hermes-pr-tag-listener.call.yml.example
@@ -1,0 +1,31 @@
+# Example call-site for any repo (drop in `.github/workflows/hermes-pr-tag-listener.call.yml`).
+# Then `git mv` to `.yml` once Slack webhook secret is configured.
+#
+# Required secrets:
+#   HERMES_SLACK_WEBHOOK_URL — incoming webhook for the target Slack channel
+# Optional (for Option B):
+#   HERMES_AO_DISPATCH_TOKEN  — bearer token for the local AO dispatcher
+
+name: hermes-pr-tag-listener
+
+on:
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  notify:
+    uses: jleechanorg/.github/.github/workflows/hermes-pr-tag-listener.yml@main
+    with:
+      slack_channel: '#worldai-bugs'
+      dispatch_ao: 'false'
+    secrets:
+      slack_webhook_url: ${{ secrets.HERMES_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/hermes-pr-tag-listener.yml
+++ b/.github/workflows/hermes-pr-tag-listener.yml
@@ -1,0 +1,179 @@
+# .github/workflows/hermes-pr-tag-listener.yml
+# Reusable workflow: tag @hermes (U0AEZC7RX1Q) on a PR → notify Slack + AO dispatcher.
+# Option A: Slack-only post. Option B: also auto-spawn an AO worker (set `dispatch_ao: true`).
+#
+# Call site in any consuming repo (~/.github/workflows/hermes-pr-tag-listener.call.yml):
+#   on:
+#     pull_request: { types: [opened, edited] }
+#     issue_comment: { types: [created, edited] }
+#   permissions:
+#     contents: read
+#     pull-requests: read
+#     issues: read
+#   jobs:
+#     notify:
+#       uses: jleechanorg/.github/.github/workflows/hermes-pr-tag-listener.yml@main
+#       with:
+#         slack_channel: '#worldai-bugs'   # or channel ID C0BDEAJH8PK
+#         dispatch_ao: 'false'             # 'true' to also enqueue AO worker via dispatch-task
+#       secrets:
+#         slack_webhook_url: ${{ secrets.HERMES_SLACK_WEBHOOK_URL }}
+#         ao_dispatch_token: ${{ secrets.HERMES_AO_DISPATCH_TOKEN }}   # only if dispatch_ao='true'
+
+name: hermes-pr-tag-listener (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      slack_channel:
+        description: 'Slack channel name (#worldai-bugs) or ID (C0BDEAJH8PK) for the @hermes ping.'
+        type: string
+        required: true
+      dispatch_ao:
+        description: "Set 'true' to also POST an AO-dispatch payload (used by Option B full loop)."
+        type: string
+        default: 'false'
+      hermes_user_id:
+        description: 'Slack user ID of the hermes bot (default U0AEZC7RX1Q).'
+        type: string
+        default: 'U0AEZC7RX1Q'
+    secrets:
+      slack_webhook_url:
+        description: 'Incoming webhook URL for the target Slack channel.'
+        required: true
+      ao_dispatch_token:
+        description: 'Optional bearer token for the AO dispatcher endpoint (only if dispatch_ao=true).'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Extract PR context
+        id: ctx
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HERMES_USER_ID: ${{ inputs.hermes_user_id }}
+        run: |
+          set -euo pipefail
+          EVENT="$EVENT_NAME"
+          REPO="${{ github.repository }}"
+          ACTOR="${{ github.actor }}"
+          PR_URL=""
+          PR_NUMBER=""
+          COMMENT_BODY=""
+          COMMENT_AUTHOR=""
+          PR_TITLE=""
+
+          if [ "$EVENT" = "issue_comment" ]; then
+            COMMENT_BODY=$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")
+            COMMENT_AUTHOR=$(jq -r '.comment.user.login // ""' "$GITHUB_EVENT_PATH")
+            PR_NUMBER=$(jq -r '.issue.number // ""' "$GITHUB_EVENT_PATH")
+            PR_URL="https://github.com/$REPO/pull/$PR_NUMBER"
+          elif [ "$EVENT" = "pull_request" ]; then
+            PR_NUMBER=$(jq -r '.pull_request.number // ""' "$GITHUB_EVENT_PATH")
+            PR_TITLE=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
+            PR_URL=$(jq -r '.pull_request.html_url // ""' "$GITHUB_EVENT_PATH")
+            COMMENT_AUTHOR="$ACTOR"
+          elif [ "$EVENT" = "pull_request_review_comment" ]; then
+            COMMENT_BODY=$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")
+            COMMENT_AUTHOR=$(jq -r '.comment.user.login // ""' "$GITHUB_EVENT_PATH")
+            PR_NUMBER=$(jq -r '.pull_request.number // ""' "$GITHUB_EVENT_PATH")
+            PR_URL="https://github.com/$REPO/pull/$PR_NUMBER"
+          else
+            echo "Unsupported event: $EVENT"; exit 0
+          fi
+
+          # Only fire when @hermes (by user ID) is mentioned. Require literal '@hermes' or
+          # the Slack ID inside <@U0AEZC7RX1Q> mention syntax, since GH users can't @-mention
+          # a Slack bot by ID directly.
+          MENTION_REGEX='@hermes\b|<@'"$HERMES_USER_ID"'>'
+          if ! printf '%s' "$COMMENT_BODY$PR_TITLE" | grep -Eqi "$MENTION_REGEX"; then
+            echo "no @hermes mention — skipping"
+            echo "fire=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "fire=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "comment_author=$COMMENT_AUTHOR" >> "$GITHUB_OUTPUT"
+          echo "comment_body<<EOF" >> "$GITHUB_OUTPUT"
+          printf '%s' "$COMMENT_BODY" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+
+      - name: Post to Slack
+        if: steps.ctx.outputs.fire == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+          CHANNEL: ${{ inputs.slack_channel }}
+          PR_URL: ${{ steps.ctx.outputs.pr_url }}
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          AUTHOR: ${{ steps.ctx.outputs.comment_author }}
+          REPO: ${{ steps.ctx.outputs.repo }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          TEXT=":wave: *@hermes tagged* by \`${AUTHOR}\` on \`${REPO}\` PR #${PR_NUMBER} — ${PR_URL}"
+
+          PAYLOAD=$(jq -nc \
+            --arg channel  "$CHANNEL" \
+            --arg text     "$TEXT" \
+            --arg pr_url   "$PR_URL" \
+            --arg pr_num   "$PR_NUMBER" \
+            --arg author   "$AUTHOR" \
+            --arg repo     "$REPO" \
+            --arg event    "$EVENT" \
+            '{channel: $channel, text: $text, blocks: [
+              {type: "section", text: {type: "mrkdwn", text: $text}},
+              {type: "context", elements: [
+                {type: "mrkdwn", text: (":link: <" + $pr_url + "|open PR>  •  event: `" + $event + "`  •  repo: `" + $repo + "`")}
+              ]}
+            ]}')
+
+          HTTP_CODE=$(curl -sS -o /tmp/slack_resp.json -w '%{http_code}' \
+            -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" "$SLACK_WEBHOOK_URL")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "slack post failed: $HTTP_CODE"
+            cat /tmp/slack_resp.json
+            exit 1
+          fi
+          echo "slack ok: $HTTP_CODE"
+
+      - name: Enqueue AO dispatch (Option B)
+        if: steps.ctx.outputs.fire == 'true' && inputs.dispatch_ao == 'true'
+        env:
+          AO_TOKEN: ${{ secrets.ao_dispatch_token }}
+          PR_URL: ${{ steps.ctx.outputs.pr_url }}
+          AUTHOR: ${{ steps.ctx.outputs.comment_author }}
+          REPO: ${{ steps.ctx.outputs.repo }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AO_TOKEN:-}" ]; then
+            echo "AO_TOKEN not set — skipping AO enqueue"
+            exit 0
+          fi
+          PAYLOAD=$(jq -nc \
+            --arg pr_url   "$PR_URL" \
+            --arg author   "$AUTHOR" \
+            --arg repo     "$REPO" \
+            --arg task     "run /skeptic + /er on $PR_URL (auto-triggered by @hermes tag from $AUTHOR)" \
+            '{pr_url: $pr_url, author: $author, repo: $repo, task: $task}')
+
+          HTTP_CODE=$(curl -sS -o /tmp/ao_resp.json -w '%{http_code}' \
+            -X POST -H "Authorization: Bearer $AO_TOKEN" \
+            -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            "${HERMES_AO_DISPATCH_URL:-http://127.0.0.1:8643/hooks/ao-dispatch}")
+          echo "AO dispatch http: $HTTP_CODE"
+          cat /tmp/ao_resp.json


### PR DESCRIPTION
## Summary
Reusable GitHub Actions workflow that listens for `@hermes` (or `<@U0AEZC7RX1Q>`) mentions on PRs/comments and forwards them to Slack, with an optional AO-dispatch path for the full /skeptic + /er loop.

## What it does
- **Trigger:** `pull_request` (opened/edited), `issue_comment` (created/edited), `pull_request_review_comment` (created/edited)
- **Filter:** only fires when comment text or PR title contains `@hermes` or `<@U0AEZC7RX1Q>`
- **Action:** POSTs Slack incoming webhook with PR URL + comment context + author
- **Option B (off by default):** when `dispatch_ao=true`, also POSTs an AO-dispatch payload to `${HERMES_AO_DISPATCH_URL}/hooks/ao-dispatch`

## How to use in another repo
```yaml
# .github/workflows/hermes-pr-tag-listener.yml
on:
  pull_request: { types: [opened, edited] }
  issue_comment: { types: [created, edited] }
  pull_request_review_comment: { types: [created, edited] }
permissions:
  contents: read
  pull-requests: read
  issues: read
jobs:
  notify:
    uses: jleechanorg/.github/.github/workflows/hermes-pr-tag-listener.yml@main
    with:
      slack_channel: '#worldai-bugs'
      dispatch_ao: 'false'
    secrets:
      slack_webhook_url: ${{ secrets.HERMES_SLACK_WEBHOOK_URL }}
```
Example file at `hermes-pr-tag-listener.call.yml.example` in this PR.

## Required secrets
- `HERMES_SLACK_WEBHOOK_URL` — Slack incoming webhook (mandatory)
- `HERMES_AO_DISPATCH_TOKEN` — bearer token for AO dispatcher (only if `dispatch_ao=true`)

## Bead
- `jleechan-ivzw` (prtag: Slack↔GitHub @hermes mention handler)
- Slack context: C09GRLXF9GR / thread 1782525164.809219

## Proof
- Reusable workflow file: `.github/workflows/hermes-pr-tag-listener.yml`
- Call-site example: `.github/workflows/hermes-pr-tag-listener.call.yml.example`
- Diff: 210 LOC added, 0 removed

## User Stories
- N/A (infrastructure / automation change, no user-visible UI)

## Follow-up
AO worker (Option B) will be dispatched separately via `dispatch-task` skill to wire the `dispatch_ao=true` path with the local AO dispatcher at `${HERMES_AO_DISPATCH_URL}`.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New automation that sends PR context to Slack and can trigger external AO dispatch with a bearer token; misconfiguration or webhook leakage could expose repo/PR metadata or spawn unintended workers.
> 
> **Overview**
> Adds a **reusable GitHub Actions workflow** so consuming repos can react when a PR or comment mentions `@hermes` or `<@U0AEZC7RX1Q>` (including `@hermes` in an edited PR title).
> 
> On a match, it posts a Slack incoming-webhook message with PR URL, repo, author, and event type. **`dispatch_ao: true`** optionally POSTs a bearer-authenticated payload to `${HERMES_AO_DISPATCH_URL:-http://127.0.0.1:8643/hooks/ao-dispatch}` to enqueue an AO task (`/skeptic` + `/er` on that PR); that step is off by default and skips if the token is missing.
> 
> Also adds **`hermes-pr-tag-listener.call.yml.example`** showing how to wire triggers (`pull_request`, `issue_comment`, `pull_request_review_comment`), read-only permissions, and `HERMES_SLACK_WEBHOOK_URL` (plus optional `HERMES_AO_DISPATCH_TOKEN`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c2a8500424ecca96cfd2233fd49e7938f78442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->