### PR TITLE
fix(workflow): change hermes-pr-tag-listener default slack_channel from #worldai-bugs to #ai-general

### DIFF
--- a/.github/workflows/hermes-pr-tag-listener.yml
+++ b/.github/workflows/hermes-pr-tag-listener.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       slack_channel:
-        description: 'Slack channel name (#worldai-bugs) or ID (C0BDEAJH8PK) for the @hermes ping.'
+        description: 'Slack channel name (#ai-general) or ID (C0AJQ5M0A0Y) for the @hermes ping. Call-sites should override per-repo to the appropriate channel.'
         type: string
-        required: true
+        default: '#ai-general'
       dispatch_ao:
         description: "Set 'true' to also POST an AO-dispatch payload."
         type: string


### PR DESCRIPTION
## User Stories
- As a maintainer of multiple jleechanorg/* repos, I want the @hermes PR-tag listener reusable workflow to default to a sensible home channel (#ai-general / C0AJQ5M0A0Y) rather than a per-repo scoped channel like #worldai-bugs (C0BDEAJH8PK).

## Background
- 2026-07-02: a jleechanorg/jleechanclaw PR (#707) @hermes tag landed in #worldai-bugs (C0BDEAJH8PK), which is scoped to the worldarchitect repo per the user's existing channel-scoping rule.
- User requested (Slack C0AH3RY3DK6/1783026856): "I asked for the hermes tag to be moved to another channel. Get it done fullrun and merge to origin main."
- The reusable workflow at `jleechanorg/.github/.github/workflows/hermes-pr-tag-listener.yml` previously had NO default value and just documented `#worldai-bugs` in the input description. Each call-site supplied its own default via `${{ vars.HERMES_SLACK_CHANNEL || '#worldai-bugs' }}`, propagating the misroute.

## Goal
- Change the reusable workflow default slack_channel to `#ai-general` (C0AJQ5M0A0Y).
- Update the input description to reference the new default.
- This is the upstream fix that lets per-repo call-sites either explicitly override (preferred) or inherit a sane home channel.

## Companion PRs
- `jleechanorg/jleechanclaw` — overrides call-site to `#all-jleechan-ai` (C09GRLXF9GR)
- `jleechanorg/worldarchitect.ai` — overrides call-site to `#worldai` (C0AH3RY3DK6)

## Changes
- `slack_channel` input: add `default: '#ai-general'`
- Update input description text from "#worldai-bugs (C0BDEAJH8PK)" to "#ai-general (C0AJQ5M0A0Y)"

## Risk
- Backward compatible: call-sites that supply `slack_channel` continue to work.
- The change adds a `default` to an input that previously had none; if any call-site was relying on no default being set, they will now silently fall back to #ai-general. Verified no such call-site exists (all call-sites supply a value via `${{ vars.HERMES_SLACK_CHANNEL || '#...' }}`).

Refs: jleechan-n488

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow input default and documentation change; no runtime logic changes, and explicit call-site overrides remain unchanged.
> 
> **Overview**
> The reusable **`hermes-pr-tag-listener`** workflow now **defaults `slack_channel` to `#ai-general`** (C0AJQ5M0A0Y) instead of requiring callers to pass a channel with docs pointing at `#worldai-bugs`.
> 
> The **`slack_channel` input** is no longer required; it has an explicit default, and the description tells call-sites to override per repo. Callers that still pass `slack_channel` behave as before; only workflows that omit the input will post to `#ai-general`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b78d377e076d64f68162913f0f2a10d0048989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->