### PR TITLE
feat(workflow): auto-derive slack_channel from github.repository

### DIFF
--- a/.github/workflows/hermes-pr-tag-listener.yml
+++ b/.github/workflows/hermes-pr-tag-listener.yml
@@ -37,6 +37,71 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - name: Derive Slack channel from repo (auto-routing default)
+        id: route
+        env:
+          INPUT_CHANNEL: ${{ inputs.slack_channel }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          # Auto-derive channel from repo when caller left the input as the default
+          # ('#ai-general'). Call-sites that explicitly override (e.g. '#jleechanclaw',
+          # '#worldai') are honored as-is. This makes the SOUL.md per-repo routing
+          # table (COMMIT hermes-tag-webhook-per-repo-routing) the default for any
+          # jleechanorg/* repo that uses the reusable workflow without an explicit
+          # slack_channel override.
+          CHANNEL="$INPUT_CHANNEL"
+
+          if [ "$CHANNEL" = "#ai-general" ] || [ -z "$CHANNEL" ]; then
+            case "$REPO" in
+              jleechanorg/jleechanclaw|jleechanorg/jleechanclaw_pub)
+                CHANNEL='#jleechanclaw' ;;
+              jleechanorg/worldarchitect.ai)
+                CHANNEL='#worldai' ;;
+              jleechanorg/.github)
+                CHANNEL='#worldai' ;;
+              jleechanorg/worldai*|jleechanorg/worldai_claw|jleechanorg/worldai-mcp|jleechanorg/worldai_genesis*)
+                CHANNEL='#worldai' ;;
+              jleechanorg/agent-orchestrator|jleechanorg/dark-factory*)
+                CHANNEL='#agent-orchestrator' ;;
+              jleechanorg/cmux*)
+                CHANNEL='#cmux' ;;
+              jleechanorg/ai_universe*)
+                CHANNEL='#ai-universe' ;;
+              jleechanorg/browserclaw)
+                CHANNEL='#browserclaw' ;;
+              jleechanorg/cindil-health)
+                CHANNEL='#cindil-health' ;;
+              jleechanorg/jleechanbrain|jleechanbrain/*)
+                CHANNEL='#jleechanbrain' ;;
+              jleechanorg/hermes-agent_archive*)
+                CHANNEL='#hermes-archive' ;;
+              jleechanorg/mcp_mail|jleechanorg/mcp_lego|jleechanorg/agent_bridge)
+                CHANNEL='#mcp-mail' ;;
+              jleechanorg/llm*)
+                CHANNEL='#llm' ;;
+              jleechanorg/ralph*)
+                CHANNEL='#ralph-status' ;;
+              jleechanorg/openclaw*)
+                CHANNEL='#openclaw-chatter' ;;
+              *)
+                # Org-wide default for jleechanorg/* and unknown repos
+                if [ "$OWNER" = "jleechanorg" ]; then
+                  CHANNEL='#ai-general'
+                else
+                  # Other orgs (e.g. Agnt-F) get their own default — caller can override via input
+                  CHANNEL='#ai-general'
+                fi
+                ;;
+            esac
+            echo "auto-routed $REPO -> $CHANNEL"
+          else
+            echo "explicit channel from caller: $CHANNEL"
+          fi
+
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+
       - name: Extract PR context
         id: ctx
         env:
@@ -191,7 +256,7 @@ jobs:
         if: steps.ctx.outputs.fire == 'true' && steps.ctx.outputs.completion != 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
-          CHANNEL: ${{ inputs.slack_channel }}
+          CHANNEL: ${{ steps.route.outputs.channel }}
           PR_URL: ${{ steps.ctx.outputs.pr_url }}
           PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
           AUTHOR: ${{ steps.ctx.outputs.comment_author }}
@@ -267,7 +332,7 @@ jobs:
           RESULT: ${{ steps.ctx.outputs.result }}
           TASK_ID: ${{ steps.ctx.outputs.task_id }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
-          CHANNEL: ${{ inputs.slack_channel }}
+          CHANNEL: ${{ steps.route.outputs.channel }}
           PR_URL: ${{ steps.ctx.outputs.pr_url }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Makes the SOUL.md COMMIT `hermes-tag-webhook-per-repo-routing` the DEFAULT for any `jleechanorg/*` repo that uses the reusable `hermes-pr-tag-listener.yml` workflow. Existing call-sites that pass an explicit `slack_channel` are honored as-is.

## Why

Previously each `jleechanorg/*` repo needed its own `.github/workflows/hermes-pr-tag-listener.yml` call-site to override `slack_channel`. New repos would default to `#ai-general` (or worse, `#worldai-bugs` before [PR #12](https://github.com/jleechanorg/.github/pull/12)).

With this PR, the reusable workflow itself derives the right channel from `github.repository` automatically. Per-repo call-site files become optional — only needed when a repo wants a channel outside the routing table.

## Routing table (encoded in workflow)

| Repo pattern | Channel |
|---|---|
| `jleechanorg/jleechanclaw*` | `#jleechanclaw` |
| `jleechanorg/worldarchitect.ai` | `#worldai` |
| `jleechanorg/.github` | `#worldai` |
| `jleechanorg/worldai*` | `#worldai` |
| `jleechanorg/agent-orchestrator`, `jleechanorg/dark-factory*` | `#agent-orchestrator` |
| `jleechanorg/cmux*` | `#cmux` |
| `jleechanorg/ai_universe*` | `#ai-universe` |
| `jleechanorg/browserclaw` | `#browserclaw` |
| `jleechanorg/cindil-health` | `#cindil-health` |
| `jleechanorg/jleechanbrain*` | `#jleechanbrain` |
| `jleechanorg/mcp_mail`, `mcp_lego`, `agent_bridge` | `#mcp-mail` |
| `jleechanorg/llm*` | `#llm` |
| `jleechanorg/ralph*` | `#ralph-status` |
| `jleechanorg/openclaw*` | `#openclaw-chatter` |
| any other `jleechanorg/*` | `#ai-general` |

`#all-jleechan-ai` (C09GRLXF9GR) is **never** an auto-route target — reserved per `slack-channel-routing-policy` for direct Hermes conversations. `#worldai-bugs` (C0BDEAJH8PK) is **never** auto-routed.

## Production Code Changes

- New step `Derive Slack channel from repo (auto-routing default)` runs before `Post to Slack` and `Post final completion comment on the PR`
- Updated `CHANNEL` env in two steps to use `steps.route.outputs.channel` instead of `inputs.slack_channel`
- +67 / -2 lines, single file

## Test Changes

None. This is a workflow-only change with no application runtime.

## Known Limitations

- Existing call-sites in `jleechanorg/jleechanclaw` and `jleechanorg/worldarchitect.ai` still explicitly pass `slack_channel`. They are honored as-is (not overridden). Cleanup PR can remove the redundant call-site overrides later if desired.
- The routing table is hardcoded in the workflow YAML. To add a new repo pattern, edit the `case` statement.

## Unit Test Evidence

N/A — workflow YAML, validated by GitHub Actions parser on push and CodeRabbit review.

## Non-Unit Test Evidence

Verification flow:
```text
@hermes tag on any jleechanorg/* PR or comment
  -> Call-site invokes reusable workflow with slack_channel=default
  -> route step applies per-repo routing table
  -> Post to Slack uses steps.route.outputs.channel
  -> Message lands in correct per-repo channel
```

## Real LLM Evidence

N/A — pure event-routing, no LLM invocation.

## Evidence

- Branch: https://github.com/jleechanorg/.github/tree/feat/auto-derive-slack-channel
- Diff: https://github.com/jleechanorg/.github/pull/13/files
- Source thread: [Slack C0AH3RY3DK6/p1783026856.393809](https://jleechanai.slack.com/archives/C0AH3RY3DK6/p1783026856.393809) — user said "I dont wanna ask again" re: webhook routing
- Prior PRs: [jleechanorg/.github#12](https://github.com/jleechanorg/.github/pull/12), [jleechanorg/jleechanclaw#712](https://github.com/jleechanorg/jleechanclaw/pull/712), [jleechanorg/worldarchitect.ai#8137](https://github.com/jleechanorg/worldarchitect.ai/pull/8137)
- SOUL.md COMMIT: `hermes-tag-webhook-per-repo-routing` (jleechanorg/jleechanclaw@main d43fbdb258)

## User Stories

- Actor: maintainer creating a new `jleechanorg/*` repo that wants @hermes PR-tag notifications
- Action: adds the reusable call-site workflow without specifying `slack_channel`
- Outcome: notifications auto-route to the right per-repo channel with zero config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only notification routing with no runtime code; wrong `case` patterns could misdeliver Slack messages but do not touch auth or application data.
> 
> **Overview**
> The reusable **hermes-pr-tag-listener** workflow now picks the Slack destination from `github.repository` when callers leave `slack_channel` at the default (`#ai-general`) or empty. A new **`Derive Slack channel from repo`** step maps `jleechanorg/*` repos to per-repo channels (e.g. `worldai*` → `#worldai`, `jleechanclaw*` → `#jleechanclaw`); anything unmatched in the org still goes to `#ai-general`. **Explicit `slack_channel` overrides are unchanged.**
> 
> **Post to Slack** and the **completion** Slack post now use `steps.route.outputs.channel` instead of `inputs.slack_channel`, so new repos can wire the reusable workflow without per-repo call-site channel overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68d42e13714c5b21c9fe17febc1893b78817caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->