### PR TITLE
ci(hermes-listener): job-level if: pre-filter to skip billed runner minutes

### DIFF
--- a/.github/workflows/hermes-pr-tag-listener.yml
+++ b/.github/workflows/hermes-pr-tag-listener.yml
@@ -34,6 +34,20 @@ permissions:
 
 jobs:
   notify:
+    # Job-level pre-filter: skip runner provisioning entirely (no billed minute)
+    # unless the event can plausibly contain an @hermes mention. This mirrors
+    # the case-insensitive substring match the "Extract PR context" step below
+    # performs with `grep -Eqi '@hermes\b|<@USER_ID>'`, minus the \b word
+    # boundary (contains() has no regex support — see Known Limitations in
+    # the PR description). repository_dispatch always runs: it is the
+    # hermes-task-completed notification path, not a high-volume trigger, and
+    # its own action/repo match is still validated inside the bash step.
+    if: >-
+      github.event_name == 'repository_dispatch' ||
+      contains(github.event.comment.body, '@hermes') ||
+      contains(github.event.comment.body, format('<@{0}>', inputs.hermes_user_id)) ||
+      contains(github.event.pull_request.title, '@hermes') ||
+      contains(github.event.pull_request.title, format('<@{0}>', inputs.hermes_user_id))
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
## Summary

- Add a job-level `if:` pre-filter to the `notify` job in `hermes-pr-tag-listener.yml` (reusable workflow) so GitHub Actions skips runner provisioning entirely for events that cannot contain an `@hermes` mention — turning a no-op run into a **zero-billed-minute** skipped job instead of a fully-provisioned `ubuntu-latest` runner that just exits early.
- All existing steps, the bash-level mention regex, and the `workflow_call` inputs/secrets interface are unchanged — the bash check remains as defense-in-depth.

## Background

- Per the design review backing this change (bead `rev-82m0c`): **11,835 `notify` job runs/week** org-wide across all repos calling this reusable workflow, and roughly a **1% @hermes-mention hit rate** from a 300-comment sample of `issue_comment` / `pull_request_review_comment` triggers — the other ~99% run the job purely to reach the `grep -Eqi` no-match branch and exit. These figures are cited as design input, not re-measured in this PR; this PR only changes the job-level `if:` gate.
- GitHub-hosted runner billing rounds each job **up to the next whole minute**, so every no-op run still bills 1 minute even though the bash filter step itself takes a few seconds.
- At ~99% no-op rate over 11,835 runs/week, that's roughly **$290-410/mo** in wasted GitHub Actions minutes org-wide. A job-level `if:` that evaluates to `false` means the job is *skipped* — GitHub does not provision a runner and does not bill a minute for it. Projected cost after this change: **~$4-8/mo** (residual billing only for runs that plausibly match, including the always-on `repository_dispatch` completion path).

## Truth Table

`inputs.hermes_user_id` defaults to `U0AEZC7RX1Q`. The bash step's regex is `@hermes\b|<@$HERMES_USER_ID>`, matched case-insensitively (`grep -Eqi`) against `$COMMENT_BODY$PR_TITLE`.

| Event | Trigger field scanned by bash step | Job-level `if:` condition | `if:` result | Job runs? | Bash step still matches? |
|---|---|---|---|---|---|
| `issue_comment` | `comment.body` | `contains(github.event.comment.body, '@hermes')` or `<@USER_ID>` form | **true** when body has mention | Yes | Yes → fires |
| `issue_comment` | `comment.body` | (no mention in body) | **false** | **No — skipped, not billed** | n/a |
| `pull_request_review_comment` | `comment.body` | same as above | true when body has mention | Yes | Yes → fires |
| `pull_request_review_comment` | `comment.body` | (no mention) | false | **No — skipped, not billed** | n/a |
| `pull_request` (opened/edited) | `pull_request.title` only (bash never scans PR body) | `contains(github.event.pull_request.title, '@hermes')` or `<@USER_ID>` form | true when title has mention | Yes | Yes → fires |
| `pull_request` (opened/edited) | `pull_request.title` | (no mention in title) | false | **No — skipped, not billed** | n/a |
| `repository_dispatch` (any `action`) | n/a (bash gates on `action == 'hermes-task-completed'` and repo match) | `github.event_name == 'repository_dispatch'` | **always true** | Yes (unconditionally) | Existing bash logic still gates completion vs. non-matching dispatch |

`repository_dispatch` is intentionally never job-level-filtered: it's the low-volume `hermes-task-completed` completion-notify path, not a driver of the 11,835/week no-op volume, and filtering it at the job level risked silently dropping a completion notification. Its existing bash-level `action`/repo match is untouched.

## Testing

```
$ actionlint .github/workflows/hermes-pr-tag-listener.yml
.github/workflows/hermes-pr-tag-listener.yml:60:9: shellcheck reported issue in this script: SC2221:warning:18:5: This pattern always overrides a later one on line 19 [shellcheck]
.github/workflows/hermes-pr-tag-listener.yml:60:9: shellcheck reported issue in this script: SC2222:warning:18:26: This pattern never matches because of a previous pattern on line 19 [shellcheck]
.github/workflows/hermes-pr-tag-listener.yml:124:9: shellcheck reported issue in this script: SC2129:style:52:3: Consider using { cmd1; cmd2; } >> file instead of individual redirects [shellcheck]
.github/workflows/hermes-pr-tag-listener.yml:124:9: shellcheck reported issue in this script: SC2129:style:77:1: Consider using { cmd1; cmd2; } >> file instead of individual redirects [shellcheck]
```

The 4 findings above are **pre-existing** on `main` (verified by running `actionlint` against the unmodified file via `git stash` — identical findings, only line numbers shift). `actionlint` reports **zero new findings** introduced by this change; there are no syntax/expression errors in the new `if:` block itself.

Also manually evaluated the new `if:` expression against every event/payload shape in the truth table above by hand-tracing the GitHub Actions expression semantics (`contains()` casts non-existent nested properties, e.g. `github.event.comment` on a `pull_request` event, to `null` → `''`, so it safely returns `false` rather than erroring).

## Known Limitations

- `contains()` has no regex support, so the job-level filter drops the bash regex's `\b` word-boundary after `hermes` (e.g. `@hermesbot` would pass the job-level filter but still correctly get rejected by the unchanged bash step — a rare, safe **over-inclusion**, never an under-inclusion/missed-mention).
- Case sensitivity actually matches exactly: GitHub Actions' `contains()` is documented as case-insensitive, identical to the bash step's `grep -Eqi`, so `@Hermes`, `@HERMES`, etc. all still match at the job level — no narrowing versus current behavior.
- The `<@USER_ID>` Slack-mention form is matched via `format('<@{0}>', inputs.hermes_user_id)`, so if a caller overrides `hermes_user_id`, the job-level filter still tracks it correctly.
- A skipped job still appears as a `notify` check-run in the PR checks list, shown as **"skipped"** rather than disappearing — this is standard GitHub Actions `if:`-skip behavior and does not affect required-check semantics for callers that don't mark it required.
- This PR does not change the `pull_request` event to also scan the PR body — it mirrors the existing bash step's behavior of only scanning `pull_request.title`, not `pull_request.body`.

## Rollback

Single-commit, stateless workflow-file change. Rollback via `git revert <this-commit-sha>` on `main` — no data migration, no secrets/inputs interface change, nothing else to unwind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only cost optimization with no change to secrets, inputs, or notification logic; the existing bash mention filter still gates real dispatches.
> 
> **Overview**
> Adds a **job-level `if:`** on the reusable `notify` job in `hermes-pr-tag-listener.yml` so GitHub **skips provisioning a runner** (and avoids the ~1 minute billing floor) when the payload cannot plausibly include an `@hermes` or `<@hermes_user_id>` mention in `comment.body` or `pull_request.title`.
> 
> **`repository_dispatch` events always run** so the low-volume `hermes-task-completed` path is unchanged; existing bash `grep` mention checks and all notify steps stay as **defense-in-depth**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bd49e0d99aa9b6731d8db699ceb14012c9ed4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->