### PR TITLE
ci: run reusable Hermes listener on self-hosted runner

### DIFF
--- a/.github/workflows/hermes-pr-tag-listener.yml
+++ b/.github/workflows/hermes-pr-tag-listener.yml
@@ -48,7 +48,7 @@ jobs:
       contains(github.event.comment.body, format('<@{0}>', inputs.hermes_user_id)) ||
       contains(github.event.pull_request.title, '@hermes') ||
       contains(github.event.pull_request.title, format('<@{0}>', inputs.hermes_user_id))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, self-hosted-mikey]
     timeout-minutes: 3
     steps:
       - name: Derive Slack channel from repo (auto-routing default)


### PR DESCRIPTION
## Summary
- run the reusable Hermes PR-tag listener notify job on `self-hosted-mikey`
- preserve its trigger, permissions, and notification behavior

## Verification
- `python3` YAML parse plus exact runner-selector assertion
- `actionlint` (custom runner label and existing shellcheck advisories ignored)
- `git diff --check`

## Evidence
https://gist.github.com/jleechan2015/37591bcc943c39945588ae1f78e3a815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single runner-label change with no workflow logic or secret-handling changes; main risk is job queueing or runner availability on the self-hosted pool.
> 
> **Overview**
> Moves the reusable **hermes-pr-tag-listener** `notify` job off GitHub-hosted `ubuntu-latest` onto the **`self-hosted-mikey`** runner pool (`runs-on: [self-hosted, self-hosted-mikey]`).
> 
> Triggers, job-level `if` pre-filter, permissions, secrets, and Slack/GitHub notification steps are unchanged—only where the job executes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06150ceda431130693f9723cb7ae3c7352a7d676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->